### PR TITLE
Workaround bug in chrome driver

### DIFF
--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/selenium/SeleniumDrivenBrowser.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/selenium/SeleniumDrivenBrowser.java
@@ -37,18 +37,25 @@ import org.slf4j.LoggerFactory;
  */
 class SeleniumDrivenBrowser implements IBrowser
 {
-	private final static int DEFAULT_TIMEOUT = 10;
-
-	private final Logger logger = LoggerFactory.getLogger(SeleniumDrivenBrowser.class);
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(SeleniumDrivenBrowser.class);
+	private static final int DEFAULT_TIMEOUT = 10;
 
 	private final RemoteWebDriver driver;
 	private final SeleniumWindowManager windowManager;
+	
+	private final String browserName;
+	private final String browserVersion;
 
 	SeleniumDrivenBrowser(RemoteWebDriver driver)
 	{
 		this.driver = driver;
 		this.windowManager = new SeleniumWindowManager(this.driver);
 		this.driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(DEFAULT_TIMEOUT));
+		this.browserName = this.driver.getCapabilities().getBrowserName();
+		this.browserVersion = this.driver.getCapabilities().getBrowserVersion();
+		
+		LOGGER.info(String.format("Using browser %s version %s", this.browserName, this.browserVersion));
 	}
 
 	@Override
@@ -60,20 +67,30 @@ class SeleniumDrivenBrowser implements IBrowser
 	@Override
 	public IBrowserWindow switchToWindow(String windowName)
 	{
-		this.logger.info(String.format("Switch to window [%s].", windowName));
+		LOGGER.info(String.format("Switch to window [%s].", windowName));
 		return this.windowManager.switchToWindow(windowName);
 	}
 
 	@Override
 	public IBrowserWindow openNewWindow()
 	{
-		this.logger.info(String.format("Openning new window."));
+		LOGGER.info(String.format("Openning new window."));
 		return this.windowManager.openNewWindow();
 	}
 
 	@Override
+	@SuppressWarnings("MagicNumber")
 	public void exit()
 	{
+		LOGGER.info("Closing browser.");
+		if("chrome".equals(this.browserName))
+		{
+		  int majorVersion = Integer.parseInt(this.browserVersion.split("[.]")[0]);
+		  if(majorVersion <= 127 && majorVersion >= 123)
+		  {
+				this.driver.close();
+		  }
+		}
 		this.driver.quit();
 	}
 }

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/reserved/selenium/SeleniumDrivenBrowserTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/reserved/selenium/SeleniumDrivenBrowserTest.java
@@ -27,11 +27,18 @@ import io.github.jamoamo.webjourney.reserved.selenium.SeleniumWindow;
 import io.github.jamoamo.webjourney.reserved.selenium.SeleniumDrivenBrowser;
 import io.github.jamoamo.webjourney.api.web.IBrowserWindow;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.BeforeAll;
+
 import static org.mockito.ArgumentMatchers.any;
+
 import org.mockito.Mockito;
+import org.openqa.selenium.Capabilities;
+
 import static org.mockito.Mockito.verify;
+
 import org.openqa.selenium.WebDriver.Options;
 import org.openqa.selenium.WebDriver.TargetLocator;
 import org.openqa.selenium.WebDriver.Timeouts;
@@ -54,6 +61,10 @@ public class SeleniumDrivenBrowserTest
 		  Options optionsMock = Mockito.mock(Options.class);
 		  Mockito.when(optionsMock.timeouts())
 				.thenReturn(timeoutsMock);
+		  
+		  Capabilities capabilitiesMock = Mockito.mock(Capabilities.class);
+		  Mockito.when(capabilitiesMock.getBrowserVersion()).thenReturn("v1.0.1");
+		  Mockito.when(capabilitiesMock.getBrowserName()).thenReturn("Test Browser");
 
 		  Mockito.when(driverMock.manage())
 				.thenReturn(optionsMock);
@@ -61,6 +72,8 @@ public class SeleniumDrivenBrowserTest
 				.thenReturn(targetLocatorMock);
 		  Mockito.when(driverMock.getWindowHandle())
 				.thenReturn("Window1");
+		  Mockito.when(driverMock.getCapabilities())
+				.thenReturn(capabilitiesMock);
 	 }
 
 	 /**


### PR DESCRIPTION
Chrome driver would leave chrome processes running despite quit being called. Workaround is to call close on the driver first. Will apparently be fixed in chrome 128.