### PR TITLE
Plan webjourney-test module improvements

### DIFF
--- a/webjourney-test/README.md
+++ b/webjourney-test/README.md
@@ -1,2 +1,37 @@
 # webjourney-test
- 
+
+A test utility for `webjourney` consumers to run browserless tests using in-memory mocks.
+
+- Mock implementations: `IBrowser`, `IBrowserWindow`, `IWebPage`, `AElement`
+- Router to map URL -> page
+- Fluent DOM builder for elements
+- Factory to integrate with `PreferredBrowserStrategy`
+
+Quick start
+
+```java
+import io.github.jamoamo.webjourney.WebTraveller;
+import io.github.jamoamo.webjourney.api.IJourney;
+import io.github.jamoamo.webjourney.api.web.DefaultBrowserOptions;
+import io.github.jamoamo.webjourney.test.mock.*;
+
+MockRouter router = new MockRouter();
+MockWebPage home = Pages.html(
+    MockElement.tag("div").attr("id","main")
+        .child(MockElement.tag("a").attr("href","https://example/next").text("Next"))
+).title("Home");
+MockWebPage next = Pages.html(MockElement.tag("h1").text("Done")).title("Next");
+router.route("https://example/home", home)
+      .route("https://example/next", next);
+
+MockBrowser browser = new MockBrowser(router);
+var strategy = MockJourneys.using(browser);
+
+// your journey using strategy via TravelOptions
+```
+
+Notes
+- `IWebPage.getElement(xPath, optional)` supports a minimal XPath subset: `//tag[@attr='value']`.
+- `IBrowserWindow.navigateBack/Forward` throw `XNavigationError` when history is empty.
+- Attach element handlers via `onClick` and `onTextEntry` for side-effects. 
+

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/TestCreator.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/TestCreator.java
@@ -30,6 +30,10 @@ import io.github.jamoamo.webjourney.reserved.entity.EntityDefn;
 import io.github.jamoamo.webjourney.reserved.entity.XEntityDefinitionException;
 import io.github.jamoamo.webjourney.reserved.entity.XEntityFieldScrapeException;
 import java.util.ArrayList;
+import io.github.jamoamo.webjourney.api.web.XWebException;
+import io.github.jamoamo.webjourney.test.mock.MockBrowser;
+import io.github.jamoamo.webjourney.test.mock.MockBrowserWindow;
+import io.github.jamoamo.webjourney.test.mock.MockRouter;
 
 /**
  * Entity Creation tester.
@@ -92,5 +96,29 @@ public final class TestCreator<T>
 			result.setFailureException(ex);
 		}
 		return result;
+	}
+
+	/**
+	 * Convenience: create an entity using a MockBrowser initialised with a router and initial URL.
+	 * @param router the router
+	 * @param initialUrl the initial URL to load (may be null)
+	 * @return the creation result
+	 */
+	public CreationResult<T> createEntityWith(MockRouter router, String initialUrl)
+	{
+		MockBrowser browser = new MockBrowser(router);
+		try
+		{
+			MockBrowserWindow window = (MockBrowserWindow) browser.getActiveWindow();
+			window.loadInitial(initialUrl);
+		}
+		catch(XWebException | RuntimeException ex)
+		{
+			CreationResult<T> r = new CreationResult<>();
+			r.setResult(CreationResult.Result.FAILED);
+			r.setFailureException(ex);
+			return r;
+		}
+		return createEntityWith((IBrowser) browser);
 	}
 }

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MissingElement.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MissingElement.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.AElement;
+import io.github.jamoamo.webjourney.api.web.XElementDoesntExistException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a required element that is missing. All operations throw.
+ */
+final class MissingElement extends AElement
+{
+	private XElementDoesntExistException error()
+	{
+		return new XElementDoesntExistException();
+	}
+
+	@Override
+	public String getAttribute(String attribute) throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public String getElementText() throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public AElement findElement(String path) throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public AElement findElement(String path, boolean optional) throws XElementDoesntExistException
+	{
+		if(optional)
+		{
+			return new NullElement();
+		}
+		throw error();
+	}
+
+	@Override
+	public List<? extends AElement> findElements(String path) throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public void click() throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public void enterText(String text) throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public List<? extends AElement> getChildrenByTag(String childElementType) throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public String getTag() throws XElementDoesntExistException
+	{
+		throw error();
+	}
+
+	@Override
+	public boolean exists()
+	{
+		return false;
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockBrowser.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockBrowser.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.IBrowser;
+import io.github.jamoamo.webjourney.api.web.IBrowserWindow;
+import io.github.jamoamo.webjourney.api.web.XWebException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.net.MalformedURLException;
+
+/**
+ * Mock implementation of IBrowser managing windows and a router.
+ */
+public final class MockBrowser implements IBrowser
+{
+	private final MockRouter router;
+	private final Map<String, MockBrowserWindow> windows = new LinkedHashMap<>();
+
+	public MockBrowser(MockRouter router)
+	{
+		this.router = router == null ? new MockRouter() : router;
+		String main = UUID.randomUUID().toString();
+		MockBrowserWindow window = new MockBrowserWindow(main, this.router);
+		window.setActive(true);
+		this.windows.put(main, window);
+	}
+
+	public MockRouter getRouter()
+	{
+		return this.router;
+	}
+
+	public void loadInitial(String url) throws XWebException, MalformedURLException
+	{
+		MockBrowserWindow window = (MockBrowserWindow) getActiveWindow();
+		window.loadInitial(url);
+	}
+
+	@Override
+	public IBrowserWindow getActiveWindow() throws XWebException
+	{
+		return this.windows.values().stream().filter(MockBrowserWindow::isActive).findFirst().orElse(null);
+	}
+
+	@Override
+	public IBrowserWindow switchToWindow(String windowName) throws XWebException
+	{
+		this.windows.values().forEach(w -> w.setActive(false));
+		MockBrowserWindow window = this.windows.get(windowName);
+		if(window != null)
+		{
+			window.setActive(true);
+		}
+		return window;
+	}
+
+	@Override
+	public IBrowserWindow openNewWindow() throws XWebException
+	{
+		this.windows.values().forEach(w -> w.setActive(false));
+		String name = UUID.randomUUID().toString();
+		MockBrowserWindow window = new MockBrowserWindow(name, this.router);
+		this.windows.put(name, window);
+		window.setActive(true);
+		return window;
+	}
+
+	@Override
+	public void exit()
+	{
+		this.windows.clear();
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockBrowserWindow.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockBrowserWindow.java
@@ -1,0 +1,195 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.IBrowserWindow;
+import io.github.jamoamo.webjourney.api.web.IWebPage;
+import io.github.jamoamo.webjourney.api.web.XNavigationError;
+import io.github.jamoamo.webjourney.api.web.XWebException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * Mock implementation of IBrowserWindow with in-memory history and router.
+ */
+final class MockBrowserWindow implements IBrowserWindow
+{
+	private final String name;
+	private final MockRouter router;
+
+	private boolean active = false;
+	private MockWebPage currentPage;
+	private URL currentUrl;
+
+	private final Deque<URL> backStack = new ArrayDeque<>();
+	private final Deque<URL> forwardStack = new ArrayDeque<>();
+
+	MockBrowserWindow(String name, MockRouter router)
+	{
+		this.name = name;
+		this.router = router;
+	}
+
+	void setActive(boolean active)
+	{
+		this.active = active;
+	}
+
+	boolean isActive()
+	{
+		return this.active;
+	}
+
+	@Override
+	public String getCurrentUrl() throws XWebException
+	{
+		ensureActive();
+		return this.currentUrl == null ? null : this.currentUrl.toString();
+	}
+
+	@Override
+	public IWebPage getCurrentPage() throws XWebException
+	{
+		ensureActive();
+		return this.currentPage;
+	}
+
+	@Override
+	public IWebPage refreshCurrentPage() throws XWebException
+	{
+		ensureActive();
+		if(this.currentUrl == null)
+		{
+			return this.currentPage;
+		}
+		MockWebPage page = this.router.resolve(this.currentUrl);
+		if(page == null)
+		{
+			throw new XNavigationError("No page for URL: " + this.currentUrl);
+		}
+		this.currentPage = page;
+		return this.currentPage;
+	}
+
+	@Override
+	public void close() throws XWebException
+	{
+		ensureActive();
+		this.active = false;
+	}
+
+	@Override
+	public String getName() throws XWebException
+	{
+		return this.name;
+	}
+
+	@Override
+	public String getTitle()
+	{
+		return this.currentPage == null ? null : this.currentPage.getTitle();
+	}
+
+	@Override
+	public IWebPage navigateToUrl(URL url) throws XNavigationError
+	{
+		ensureActive();
+		MockWebPage page = this.router.resolve(url);
+		if(page == null)
+		{
+			throw new XNavigationError("No page for URL: " + url);
+		}
+		if(this.currentUrl != null)
+		{
+			this.backStack.push(this.currentUrl);
+		}
+		this.currentUrl = url;
+		this.forwardStack.clear();
+		this.currentPage = page;
+		return this.currentPage;
+	}
+
+	@Override
+	public IWebPage navigateBack() throws XNavigationError
+	{
+		ensureActive();
+		if(this.backStack.isEmpty())
+		{
+			throw new XNavigationError("No back history.");
+		}
+		this.forwardStack.push(this.currentUrl);
+		this.currentUrl = this.backStack.pop();
+		MockWebPage page = this.router.resolve(this.currentUrl);
+		if(page == null)
+		{
+			throw new XNavigationError("No page for URL: " + this.currentUrl);
+		}
+		this.currentPage = page;
+		return this.currentPage;
+	}
+
+	@Override
+	public IWebPage navigateForward() throws XNavigationError
+	{
+		ensureActive();
+		if(this.forwardStack.isEmpty())
+		{
+			throw new XNavigationError("No forward history.");
+		}
+		this.backStack.push(this.currentUrl);
+		this.currentUrl = this.forwardStack.pop();
+		MockWebPage page = this.router.resolve(this.currentUrl);
+		if(page == null)
+		{
+			throw new XNavigationError("No page for URL: " + this.currentUrl);
+		}
+		this.currentPage = page;
+		return this.currentPage;
+	}
+
+	void loadInitial(String url) throws MalformedURLException, XNavigationError
+	{
+		this.currentUrl = url == null ? null : new URL(url);
+		if(this.currentUrl != null)
+		{
+			MockWebPage page = this.router.resolve(this.currentUrl);
+			if(page == null)
+			{
+				throw new XNavigationError("No page for URL: " + this.currentUrl);
+			}
+			this.currentPage = page;
+		}
+	}
+
+	private void ensureActive() throws XWebException
+	{
+		if(!this.active)
+		{
+			throw new XWebException("Window is inactive.");
+		}
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockElement.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockElement.java
@@ -1,0 +1,249 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.AElement;
+import io.github.jamoamo.webjourney.api.web.XElementDoesntExistException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * A mock element backed by an in-memory tree. Provides simple XPath subset and handlers.
+ */
+public final class MockElement extends AElement
+{
+	private final String tag;
+	private final Map<String, String> attributes;
+	private String text;
+	private final List<MockElement> children;
+
+	private Consumer<MockElement> clickHandler;
+	private Consumer<TextEntry> textEntryHandler;
+
+	MockElement(String tag)
+	{
+		this.tag = tag;
+		this.attributes = new LinkedHashMap<>();
+		this.children = new ArrayList<>();
+		this.text = "";
+	}
+
+	public static MockElement tag(String tag)
+	{
+		return new MockElement(tag);
+	}
+
+	public MockElement attr(String name, String value)
+	{
+		this.attributes.put(name, value);
+		return this;
+	}
+
+	public MockElement text(String text)
+	{
+		this.text = text == null ? "" : text;
+		return this;
+	}
+
+	public MockElement child(MockElement child)
+	{
+		this.children.add(child);
+		return this;
+	}
+
+	public MockElement onClick(Consumer<MockElement> handler)
+	{
+		this.clickHandler = handler;
+		return this;
+	}
+
+	public MockElement onTextEntry(Consumer<TextEntry> handler)
+	{
+		this.textEntryHandler = handler;
+		return this;
+	}
+
+	@Override
+	public String getAttribute(String attribute) throws XElementDoesntExistException
+	{
+		return this.attributes.get(attribute);
+	}
+
+	@Override
+	public String getElementText() throws XElementDoesntExistException
+	{
+		return this.text;
+	}
+
+	@Override
+	public AElement findElement(String path) throws XElementDoesntExistException
+	{
+		return findElement(path, false);
+	}
+
+	@Override
+	public AElement findElement(String path, boolean optional) throws XElementDoesntExistException
+	{
+		List<MockElement> found = findAllByXPath(path);
+		if(found.isEmpty())
+		{
+			return optional ? new NullElement() : new MissingElement();
+		}
+		return found.get(0);
+	}
+
+	@Override
+	public List<? extends AElement> findElements(String path) throws XElementDoesntExistException
+	{
+		return Collections.unmodifiableList(findAllByXPath(path));
+	}
+
+	@Override
+	public void click() throws XElementDoesntExistException
+	{
+		if(this.clickHandler != null)
+		{
+			this.clickHandler.accept(this);
+		}
+	}
+
+	@Override
+	public void enterText(String text) throws XElementDoesntExistException
+	{
+		this.attributes.put("value", Objects.toString(text, ""));
+		if(this.textEntryHandler != null)
+		{
+			this.textEntryHandler.accept(new TextEntry(this, text));
+		}
+	}
+
+	@Override
+	public List<? extends AElement> getChildrenByTag(String childElementType) throws XElementDoesntExistException
+	{
+		return this.children.stream().filter(c -> Objects.equals(c.tag, childElementType)).collect(Collectors.toList());
+	}
+
+	@Override
+	public String getTag() throws XElementDoesntExistException
+	{
+		return this.tag;
+	}
+
+	@Override
+	public boolean exists()
+	{
+		return true;
+	}
+
+	List<MockElement> getChildren()
+	{
+		return this.children;
+	}
+
+	Map<String, String> getAttributes()
+	{
+		return this.attributes;
+	}
+
+	private List<MockElement> findAllByXPath(String xPath)
+	{
+		// Minimal subset: //tag[@attr='value'] and descendant search
+		if(xPath == null || xPath.isEmpty())
+		{
+			return List.of();
+		}
+		String expr = xPath.trim();
+		if(!expr.startsWith("//"))
+		{
+			return List.of();
+		}
+		expr = expr.substring(2);
+		String tagName;
+		String attrName = null;
+		String attrValue = null;
+		int bracketStart = expr.indexOf('[');
+		if(bracketStart >= 0 && expr.endsWith("]"))
+		{
+			tagName = expr.substring(0, bracketStart);
+			String inside = expr.substring(bracketStart + 1, expr.length() - 1).trim();
+			// format: @attr='value'
+			if(inside.startsWith("@"))
+			{
+				int eq = inside.indexOf('=');
+				if(eq > 1)
+				{
+					attrName = inside.substring(1, eq).trim();
+					String v = inside.substring(eq + 1).trim();
+					if(v.startsWith("'") && v.endsWith("'"))
+					{
+						attrValue = v.substring(1, v.length() - 1);
+					}
+				}
+			}
+		}
+		else
+		{
+			tagName = expr;
+		}
+		List<MockElement> results = new ArrayList<>();
+		collectDescendantsByTag(this, tagName, results);
+		if(attrName != null)
+		{
+			return results.stream()
+				.filter(e -> Objects.equals(e.attributes.get(attrName), attrValue))
+				.collect(Collectors.toList());
+		}
+		return results;
+	}
+
+	private static void collectDescendantsByTag(MockElement root, String tag, List<MockElement> into)
+	{
+		if(Objects.equals(root.tag, tag))
+		{
+			into.add(root);
+		}
+		for(MockElement c : root.children)
+		{
+			collectDescendantsByTag(c, tag, into);
+		}
+	}
+
+	public static final class TextEntry
+	{
+		public final MockElement element;
+		public final String text;
+		TextEntry(MockElement element, String text)
+		{
+			this.element = element;
+			this.text = text;
+		}
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockJourneys.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockJourneys.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.IPreferredBrowserStrategy;
+import io.github.jamoamo.webjourney.api.web.PreferredBrowserStrategy;
+
+/**
+ * Utilities for wiring mock browser into journeys.
+ */
+public final class MockJourneys
+{
+	private MockJourneys() {}
+
+	public static IPreferredBrowserStrategy using(MockBrowser browser)
+	{
+		return new PreferredBrowserStrategy(new TestBrowserFactory(browser));
+	}
+
+	public static IPreferredBrowserStrategy using(MockRouter router)
+	{
+		return new PreferredBrowserStrategy(new TestBrowserFactory(router));
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockRouter.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockRouter.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * A simple router for mapping URLs to mock pages or page providers.
+ */
+public final class MockRouter
+{
+	private final Map<String, Function<URL, MockWebPage>> urlToProvider = new ConcurrentHashMap<>();
+
+	/**
+	 * Route a specific URL to a fixed page instance.
+	 * @param url the URL string
+	 * @param page the page to return when the url is requested
+	 * @return this router for chaining
+	 */
+	public MockRouter route(String url, MockWebPage page)
+	{
+		this.urlToProvider.put(url, u -> page);
+		return this;
+	}
+
+	/**
+	 * Route a specific URL to a page provider function.
+	 * @param url the URL string
+	 * @param provider provider that receives the requested URL and returns a page
+	 * @return this router for chaining
+	 */
+	public MockRouter route(String url, Function<URL, MockWebPage> provider)
+	{
+		this.urlToProvider.put(url, provider);
+		return this;
+	}
+
+	/**
+	 * Resolve a URL to a MockWebPage if one is configured.
+	 * @param url the url
+	 * @return the page or null if no mapping exists
+	 */
+	public MockWebPage resolve(URL url)
+	{
+		Function<URL, MockWebPage> provider = this.urlToProvider.get(url.toString());
+		if(provider == null)
+		{
+			return null;
+		}
+		return provider.apply(url);
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockWebPage.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/MockWebPage.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.AElement;
+import io.github.jamoamo.webjourney.api.web.IWebPage;
+import io.github.jamoamo.webjourney.api.web.XWebException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A mock web page backed by a root mock element.
+ */
+public final class MockWebPage implements IWebPage
+{
+	private final MockElement root;
+	private String title;
+
+	private MockWebPage(MockElement root)
+	{
+		this.root = root;
+	}
+
+	public static MockWebPage root(MockElement root)
+	{
+		return new MockWebPage(root);
+	}
+
+	public MockWebPage title(String title)
+	{
+		this.title = title;
+		return this;
+	}
+
+	String getTitle()
+	{
+		return this.title;
+	}
+
+	MockElement getRoot()
+	{
+		return this.root;
+	}
+
+	@Override
+	public AElement getElement(String xPath) throws XWebException
+	{
+		return getElement(xPath, false);
+	}
+
+	@Override
+	public AElement getElement(String xPath, boolean optional) throws XWebException
+	{
+		if(this.root == null)
+		{
+			return optional ? new NullElement() : new MissingElement();
+		}
+		AElement element = this.root.findElement(xPath, true);
+		if(element == null)
+		{
+			return optional ? new NullElement() : new MissingElement();
+		}
+		return element;
+	}
+
+	@Override
+	public List<? extends AElement> getElements(String xPath) throws XWebException
+	{
+		if(this.root == null)
+		{
+			return new ArrayList<>();
+		}
+		return this.root.findElements(xPath);
+	}
+
+	@Override
+	public List<? extends AElement> getElementsByTag(String tag) throws XWebException
+	{
+		if(this.root == null)
+		{
+			return new ArrayList<>();
+		}
+		return this.root.getChildrenByTag(tag);
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/NullElement.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/NullElement.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.web.AElement;
+import io.github.jamoamo.webjourney.api.web.XElementDoesntExistException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a missing optional element. Methods return null/empty and never throw.
+ */
+final class NullElement extends AElement
+{
+	@Override
+	public String getAttribute(String attribute) throws XElementDoesntExistException
+	{
+		return null;
+	}
+
+	@Override
+	public String getElementText() throws XElementDoesntExistException
+	{
+		return null;
+	}
+
+	@Override
+	public AElement findElement(String path) throws XElementDoesntExistException
+	{
+		return this;
+	}
+
+	@Override
+	public AElement findElement(String path, boolean optional) throws XElementDoesntExistException
+	{
+		return this;
+	}
+
+	@Override
+	public List<? extends AElement> findElements(String path) throws XElementDoesntExistException
+	{
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void click() throws XElementDoesntExistException
+	{
+		// no-op
+	}
+
+	@Override
+	public void enterText(String text) throws XElementDoesntExistException
+	{
+		// no-op
+	}
+
+	@Override
+	public List<? extends AElement> getChildrenByTag(String childElementType) throws XElementDoesntExistException
+	{
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getTag() throws XElementDoesntExistException
+	{
+		return null;
+	}
+
+	@Override
+	public boolean exists()
+	{
+		return false;
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/Pages.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/Pages.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+/**
+ * Small helpers for building pages.
+ */
+public final class Pages
+{
+	private Pages() {}
+
+	public static MockWebPage html(MockElement body)
+	{
+		MockElement html = MockElement.tag("html");
+		MockElement head = MockElement.tag("head");
+		MockElement actualBody = MockElement.tag("body");
+		if(body != null)
+		{
+			actualBody.child(body);
+		}
+		html.child(head).child(actualBody);
+		return MockWebPage.root(html);
+	}
+}

--- a/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/TestBrowserFactory.java
+++ b/webjourney-test/src/main/java/io/github/jamoamo/webjourney/test/mock/TestBrowserFactory.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.test.mock;
+
+import io.github.jamoamo.webjourney.api.IJourneyContext;
+import io.github.jamoamo.webjourney.api.web.IBrowser;
+import io.github.jamoamo.webjourney.api.web.IBrowserFactory;
+import io.github.jamoamo.webjourney.api.web.IBrowserOptions;
+
+/**
+ * Factory that returns a preconfigured MockBrowser instance.
+ */
+public final class TestBrowserFactory implements IBrowserFactory
+{
+	private final MockBrowser browser;
+
+	public TestBrowserFactory(MockBrowser browser)
+	{
+		this.browser = browser;
+	}
+
+	public TestBrowserFactory(MockRouter router)
+	{
+		this.browser = new MockBrowser(router);
+	}
+
+	@Override
+	public IBrowser createBrowser(IBrowserOptions options)
+	{
+		return this.browser;
+	}
+
+	@Override
+	public IBrowser createBrowser(IBrowserOptions options, IJourneyContext journeyContext)
+	{
+		return this.browser;
+	}
+}


### PR DESCRIPTION
Introduce a mock browser stack to `webjourney-test` to enable browserless testing for `webjourney` consumers.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd584031-395a-418d-a3dc-e80f53fd0a21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd584031-395a-418d-a3dc-e80f53fd0a21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

