### PR TITLE
Implement action-level retry mechanism in webjourney

### DIFF
--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
@@ -50,7 +50,7 @@ public class JourneyContext implements IJourneyContext
 	private final Map<String, Object> inputs = new ConcurrentHashMap<>(2);
 	private final List<IJourneyObserver> journeyObservers = new CopyOnWriteArrayList<>();
 	private final IJourneyBrowserArguments browserArguments = new DefaultJourneyBrowserArguments();
-	private ActionRetryPolicy actionRetryPolicy = new ActionRetryPolicy();
+	private volatile ActionRetryPolicy actionRetryPolicy = new ActionRetryPolicy();
 	
 	void setBrowser(IBrowser browser)
 	{

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
@@ -23,6 +23,7 @@
  */
 package io.github.jamoamo.webjourney;
 
+import io.github.jamoamo.webjourney.api.ActionRetryPolicy;
 import io.github.jamoamo.webjourney.api.IJourneyBreadcrumb;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
 import io.github.jamoamo.webjourney.api.IJourneyObserver;
@@ -49,6 +50,7 @@ public class JourneyContext implements IJourneyContext
 	private final Map<String, Object> inputs = new ConcurrentHashMap<>(2);
 	private final List<IJourneyObserver> journeyObservers = new CopyOnWriteArrayList<>();
 	private final IJourneyBrowserArguments browserArguments = new DefaultJourneyBrowserArguments();
+	private ActionRetryPolicy actionRetryPolicy = new ActionRetryPolicy();
 	
 	void setBrowser(IBrowser browser)
 	{
@@ -100,5 +102,17 @@ public class JourneyContext implements IJourneyContext
 	public IJourneyBrowserArguments getBrowserArguments()
 	{
 		return this.browserArguments;
+	}
+
+	@Override
+	public void setActionRetryPolicy(ActionRetryPolicy policy)
+	{
+		this.actionRetryPolicy = policy;
+	}
+
+	@Override
+	public ActionRetryPolicy getActionRetryPolicy()
+	{
+		return this.actionRetryPolicy;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/TravelOptions.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/TravelOptions.java
@@ -23,6 +23,7 @@
  */
 package io.github.jamoamo.webjourney;
 
+import io.github.jamoamo.webjourney.api.ActionRetryPolicy;
 import io.github.jamoamo.webjourney.api.IJourneyObserver;
 import io.github.jamoamo.webjourney.api.ITravelOptions;
 import io.github.jamoamo.webjourney.api.web.IPreferredBrowserStrategy;
@@ -43,6 +44,8 @@ public final class TravelOptions implements ITravelOptions
 	
 	private List<IJourneyObserver> journeyObservers = new ArrayList<>();
 	
+	private ActionRetryPolicy actionRetryPolicy = new ActionRetryPolicy();
+
 	/**
 	 * Sets the preferred browser strategy to use. 
 	 * @param strategy the strategy to use to create the preferred browser.
@@ -80,5 +83,17 @@ public final class TravelOptions implements ITravelOptions
 	public List<IJourneyObserver> getJourneyObservers()
 	{
 		return Collections.unmodifiableList(this.journeyObservers);
+	}
+
+	@Override
+	public void setActionRetryPolicy(ActionRetryPolicy policy)
+	{
+		this.actionRetryPolicy = policy;
+	}
+
+	@Override
+	public ActionRetryPolicy getActionRetryPolicy()
+	{
+		return this.actionRetryPolicy;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/WebTraveller.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/WebTraveller.java
@@ -73,6 +73,7 @@ public class WebTraveller
 		IJourneyBreadcrumb breadcrumb = new JourneyBreadcrumb();
 		context.setJourneyBreadcrumb(breadcrumb);
 		context.setJourneyObservers(this.travelOptions.getJourneyObservers());
+		context.setActionRetryPolicy(this.travelOptions.getActionRetryPolicy());
 		
 		// Create browser with context for browser arguments
 		IBrowser browser = browserStrategy.getPreferredBrowser(new DefaultBrowserOptions(), context);

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ActionRetryPolicy.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ActionRetryPolicy.java
@@ -45,6 +45,14 @@ public class ActionRetryPolicy
 	 */
 	public ActionRetryPolicy(int maxRetries, long retryDelay, List<Class<? extends Throwable>> retryableExceptions)
 	{
+		if(maxRetries < 0)
+		{
+			throw new IllegalArgumentException("maxRetries must be non-negative");
+		}
+		if(retryDelay < 0)
+		{
+			throw new IllegalArgumentException("retryDelay must be non-negative");
+		}
 		this.maxRetries = maxRetries;
 		this.retryDelay = retryDelay;
 		this.retryableExceptions = retryableExceptions != null ? new ArrayList<>(retryableExceptions) : new ArrayList<>();

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ActionRetryPolicy.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ActionRetryPolicy.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Policy for retrying actions.
+ * @author James Amoore
+ */
+public class ActionRetryPolicy
+{
+	private final int maxRetries;
+	private final long retryDelay;
+	private final List<Class<? extends Throwable>> retryableExceptions;
+
+	/**
+	 * Creates a new retry policy.
+	 * @param maxRetries the maximum number of retries.
+	 * @param retryDelay the delay between retries in milliseconds.
+	 * @param retryableExceptions the exceptions that should trigger a retry.
+	 */
+	public ActionRetryPolicy(int maxRetries, long retryDelay, List<Class<? extends Throwable>> retryableExceptions)
+	{
+		this.maxRetries = maxRetries;
+		this.retryDelay = retryDelay;
+		this.retryableExceptions = retryableExceptions != null ? new ArrayList<>(retryableExceptions) : new ArrayList<>();
+	}
+
+	/**
+	 * Creates a new retry policy with no retries.
+	 */
+	public ActionRetryPolicy()
+	{
+		this(0, 0, Collections.emptyList());
+	}
+
+	/**
+	 * @return the maximum number of retries.
+	 */
+	public int getMaxRetries()
+	{
+		return maxRetries;
+	}
+
+	/**
+	 * @return the delay between retries in milliseconds.
+	 */
+	public long getRetryDelay()
+	{
+		return retryDelay;
+	}
+
+	/**
+	 * @return the exceptions that should trigger a retry.
+	 */
+	public List<Class<? extends Throwable>> getRetryableExceptions()
+	{
+		return Collections.unmodifiableList(retryableExceptions);
+	}
+
+	/**
+	 * Checks if a retry should be attempted.
+	 * @param attempt the current attempt number (1-based).
+	 * @param ex the exception that occurred.
+	 * @return true if a retry should be attempted.
+	 */
+	public boolean shouldRetry(int attempt, Throwable ex)
+	{
+		if(attempt > maxRetries)
+		{
+			return false;
+		}
+
+		if(retryableExceptions.isEmpty())
+		{
+			// If no exceptions specified, retry on all Exceptions (but not Errors)
+			return ex instanceof Exception;
+		}
+
+		for(Class<? extends Throwable> cls : retryableExceptions)
+		{
+			if(cls.isInstance(ex))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyContext.java
@@ -80,4 +80,16 @@ public interface IJourneyContext
 	 * @return the browser arguments.
 	 */
 	IJourneyBrowserArguments getBrowserArguments();
+
+	/**
+	 * Sets the action retry policy.
+	 * @param policy the policy to use for retrying actions.
+	 */
+	void setActionRetryPolicy(ActionRetryPolicy policy);
+
+	/**
+	 * Retrieves the action retry policy.
+	 * @return the action retry policy.
+	 */
+	ActionRetryPolicy getActionRetryPolicy();
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ITravelOptions.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ITravelOptions.java
@@ -55,5 +55,17 @@ public interface ITravelOptions
 	 * @return the journey observers
 	 */
 	List<IJourneyObserver> getJourneyObservers();
+
+	/**
+	 * Sets the action retry policy.
+	 * @param policy the policy to use for retrying actions.
+	 */
+	void setActionRetryPolicy(ActionRetryPolicy policy);
+
+	/**
+	 * Retrieves the action retry policy.
+	 * @return the action retry policy.
+	 */
+	ActionRetryPolicy getActionRetryPolicy();
 	
 }

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/AWebActionRetryTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/AWebActionRetryTest.java
@@ -10,10 +10,12 @@ import java.util.Collections;
 
 import static org.mockito.Mockito.*;
 
-public class AWebActionRetryTest {
+public class AWebActionRetryTest
+{
 
     @Test
-    public void testExecuteAction_SuccessFirstAttempt() throws Exception {
+    public void testExecuteAction_SuccessFirstAttempt() throws Exception
+    {
         TestAction action = spy(new TestAction(true));
         IJourneyContext context = mock(IJourneyContext.class);
         when(context.getActionRetryPolicy()).thenReturn(new ActionRetryPolicy());
@@ -25,7 +27,8 @@ public class AWebActionRetryTest {
     }
 
     @Test
-    public void testExecuteAction_RetrySuccess() throws Exception {
+    public void testExecuteAction_RetrySuccess() throws Exception
+    {
         TestAction action = spy(new TestAction(false, true)); // Fails once, then succeeds
         IJourneyContext context = mock(IJourneyContext.class);
         ActionRetryPolicy policy = new ActionRetryPolicy(1, 0, Collections.emptyList());
@@ -38,13 +41,15 @@ public class AWebActionRetryTest {
     }
 
     @Test
-    public void testExecuteAction_RetryFail() throws Exception {
+    public void testExecuteAction_RetryFail() throws Exception
+    {
         TestAction action = spy(new TestAction(false, false, false)); // Fails 3 times
         IJourneyContext context = mock(IJourneyContext.class);
         ActionRetryPolicy policy = new ActionRetryPolicy(1, 0, Collections.emptyList());
         when(context.getActionRetryPolicy()).thenReturn(policy);
 
-        Assertions.assertThrows(BaseJourneyActionException.class, () -> {
+        Assertions.assertThrows(BaseJourneyActionException.class, () ->
+        {
             action.executeAction(context);
         });
 
@@ -52,42 +57,52 @@ public class AWebActionRetryTest {
     }
 
     @Test
-    public void testExecuteAction_NoRetryPolicy() throws Exception {
+    public void testExecuteAction_NoRetryPolicy() throws Exception
+    {
         TestAction action = spy(new TestAction(false));
         IJourneyContext context = mock(IJourneyContext.class);
         when(context.getActionRetryPolicy()).thenReturn(null);
 
-        Assertions.assertThrows(BaseJourneyActionException.class, () -> {
+        Assertions.assertThrows(BaseJourneyActionException.class, () ->
+        {
             action.executeAction(context);
         });
 
         verify(action, times(1)).executeActionImpl(context);
     }
 
-    static class TestAction extends AWebAction {
+    static class TestAction extends AWebAction
+    {
         private final boolean[] outcomes;
         private int attempt = 0;
 
-        TestAction(boolean... outcomes) {
+        TestAction(boolean... outcomes)
+        {
             this.outcomes = outcomes;
         }
 
         @Override
-        public ActionResult executeActionImpl(IJourneyContext context) throws BaseJourneyActionException {
-            if (attempt >= outcomes.length) {
+        public ActionResult executeActionImpl(IJourneyContext context) throws BaseJourneyActionException
+        {
+            if (attempt >= outcomes.length)
+            {
                 // Default fail if we run out of outcomes (shouldn't happen in valid tests)
                 throw new BaseJourneyActionException("Failed (out of outcomes)", this, new RuntimeException("Simulated failure"));
             }
             boolean success = outcomes[attempt++];
-            if (success) {
+            if (success)
+            {
                 return ActionResult.SUCCESS;
-            } else {
+            }
+            else
+            {
                 throw new BaseJourneyActionException("Failed", this, new RuntimeException("Simulated failure"));
             }
         }
 
         @Override
-        protected String getActionName() {
+        protected String getActionName()
+        {
             return "Test Action";
         }
     }

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/AWebActionRetryTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/AWebActionRetryTest.java
@@ -1,0 +1,94 @@
+package io.github.jamoamo.webjourney.api;
+
+import io.github.jamoamo.webjourney.ActionResult;
+import io.github.jamoamo.webjourney.BaseJourneyActionException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+public class AWebActionRetryTest {
+
+    @Test
+    public void testExecuteAction_SuccessFirstAttempt() throws Exception {
+        TestAction action = spy(new TestAction(true));
+        IJourneyContext context = mock(IJourneyContext.class);
+        when(context.getActionRetryPolicy()).thenReturn(new ActionRetryPolicy());
+
+        ActionResult result = action.executeAction(context);
+
+        Assertions.assertEquals(ActionResult.SUCCESS, result);
+        verify(action, times(1)).executeActionImpl(context);
+    }
+
+    @Test
+    public void testExecuteAction_RetrySuccess() throws Exception {
+        TestAction action = spy(new TestAction(false, true)); // Fails once, then succeeds
+        IJourneyContext context = mock(IJourneyContext.class);
+        ActionRetryPolicy policy = new ActionRetryPolicy(1, 0, Collections.emptyList());
+        when(context.getActionRetryPolicy()).thenReturn(policy);
+
+        ActionResult result = action.executeAction(context);
+
+        Assertions.assertEquals(ActionResult.SUCCESS, result);
+        verify(action, times(2)).executeActionImpl(context);
+    }
+
+    @Test
+    public void testExecuteAction_RetryFail() throws Exception {
+        TestAction action = spy(new TestAction(false, false, false)); // Fails 3 times
+        IJourneyContext context = mock(IJourneyContext.class);
+        ActionRetryPolicy policy = new ActionRetryPolicy(1, 0, Collections.emptyList());
+        when(context.getActionRetryPolicy()).thenReturn(policy);
+
+        Assertions.assertThrows(BaseJourneyActionException.class, () -> {
+            action.executeAction(context);
+        });
+
+        verify(action, times(2)).executeActionImpl(context); // 1 initial + 1 retry
+    }
+
+    @Test
+    public void testExecuteAction_NoRetryPolicy() throws Exception {
+        TestAction action = spy(new TestAction(false));
+        IJourneyContext context = mock(IJourneyContext.class);
+        when(context.getActionRetryPolicy()).thenReturn(null);
+
+        Assertions.assertThrows(BaseJourneyActionException.class, () -> {
+            action.executeAction(context);
+        });
+
+        verify(action, times(1)).executeActionImpl(context);
+    }
+
+    static class TestAction extends AWebAction {
+        private final boolean[] outcomes;
+        private int attempt = 0;
+
+        TestAction(boolean... outcomes) {
+            this.outcomes = outcomes;
+        }
+
+        @Override
+        public ActionResult executeActionImpl(IJourneyContext context) throws BaseJourneyActionException {
+            if (attempt >= outcomes.length) {
+                // Default fail if we run out of outcomes (shouldn't happen in valid tests)
+                throw new BaseJourneyActionException("Failed (out of outcomes)", this, new RuntimeException("Simulated failure"));
+            }
+            boolean success = outcomes[attempt++];
+            if (success) {
+                return ActionResult.SUCCESS;
+            } else {
+                throw new BaseJourneyActionException("Failed", this, new RuntimeException("Simulated failure"));
+            }
+        }
+
+        @Override
+        protected String getActionName() {
+            return "Test Action";
+        }
+    }
+}

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/ActionRetryPolicyTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/ActionRetryPolicyTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney.api;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ActionRetryPolicy.
+ */
+public class ActionRetryPolicyTest
+{
+	@Test
+	public void testConstructor_ValidValues()
+	{
+		ActionRetryPolicy policy = new ActionRetryPolicy(3, 1000, Collections.emptyList());
+		Assertions.assertEquals(3, policy.getMaxRetries());
+		Assertions.assertEquals(1000, policy.getRetryDelay());
+	}
+
+	@Test
+	public void testConstructor_NegativeMaxRetries()
+	{
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			new ActionRetryPolicy(-1, 1000, Collections.emptyList());
+		});
+	}
+
+	@Test
+	public void testConstructor_NegativeRetryDelay()
+	{
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			new ActionRetryPolicy(3, -1, Collections.emptyList());
+		});
+	}
+
+	@Test
+	public void testConstructor_NullExceptionsList()
+	{
+		ActionRetryPolicy policy = new ActionRetryPolicy(3, 1000, null);
+		Assertions.assertNotNull(policy.getRetryableExceptions());
+		Assertions.assertTrue(policy.getRetryableExceptions().isEmpty());
+	}
+}

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
@@ -179,7 +179,7 @@ class DefaultBrowserArgumentsProviderTest
         @Override
         public ActionRetryPolicy getActionRetryPolicy()
         {
-            return null;
+            return new ActionRetryPolicy();
         }
     }
 

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.jamoamo.webjourney.api.ActionRetryPolicy;
 import io.github.jamoamo.webjourney.api.IJourneyBreadcrumb;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
 import io.github.jamoamo.webjourney.api.IJourneyObserver;
@@ -168,6 +169,17 @@ class DefaultBrowserArgumentsProviderTest
         public IJourneyBrowserArguments getBrowserArguments()
         {
             return this.args;
+        }
+
+        @Override
+        public void setActionRetryPolicy(ActionRetryPolicy policy)
+        {
+        }
+
+        @Override
+        public ActionRetryPolicy getActionRetryPolicy()
+        {
+            return null;
         }
     }
 


### PR DESCRIPTION
Introduces `ActionRetryPolicy` to handle transient failures in journey actions.
- Added `ActionRetryPolicy` class with configuration for max retries, delay, and retryable exceptions.
- Updated `ITravelOptions` and `IJourneyContext` to pass the policy through the stack.
- Modified `AWebAction.executeAction` to wrap the execution logic in a retry loop using the provided policy.
- Added unit tests for the retry mechanism.
- Fixed `DefaultBrowserArgumentsProviderTest` to implement the new interface methods.

---
*PR created automatically by Jules for task [17257708317060415264](https://jules.google.com/task/17257708317060415264) started by @jamoamo*