### PR TITLE
Add IJourneyPassenger interface and event notification mechanism

### DIFF
--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/CompleteFormAction.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/CompleteFormAction.java
@@ -25,6 +25,7 @@ package io.github.jamoamo.webjourney;
 
 import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
+import io.github.jamoamo.webjourney.api.event.FormCompletedEvent;
 import io.github.jamoamo.webjourney.annotation.form.Form;
 import io.github.jamoamo.webjourney.annotation.form.TextField;
 import io.github.jamoamo.webjourney.api.web.IBrowser;
@@ -77,6 +78,10 @@ class CompleteFormAction extends AWebAction
 				throw new JourneyException(ex);
 			}
 		}
+
+		FormCompletedEvent event = new FormCompletedEvent(context, this.form);
+		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
+
 		return ActionResult.SUCCESS;
 	}
 

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/ConsumePageAction.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/ConsumePageAction.java
@@ -72,7 +72,7 @@ class ConsumePageAction<T> extends AWebAction
 			EntityDefn entityDefn = new EntityDefn(this.pageClass);
 			EntityCreator<T> creator = new EntityCreator(entityDefn, false, context.getJourneyObservers());
 			T instance;
-			EntityCreationContext creationContext = new EntityCreationContext(entityDefn, retryPolicy);
+			EntityCreationContext creationContext = new EntityCreationContext(entityDefn, retryPolicy, context);
 			if(retryPolicy != null)
 			{
 				instance = retryPolicy.execute(() -> creator.createNewEntity(browser, creationContext));

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/JourneyContext.java
@@ -26,6 +26,7 @@ package io.github.jamoamo.webjourney;
 import io.github.jamoamo.webjourney.api.IJourneyBreadcrumb;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
 import io.github.jamoamo.webjourney.api.IJourneyObserver;
+import io.github.jamoamo.webjourney.api.IJourneyPassenger;
 import io.github.jamoamo.webjourney.api.ITravelOptions;
 import io.github.jamoamo.webjourney.api.web.DefaultJourneyBrowserArguments;
 import io.github.jamoamo.webjourney.api.web.IBrowser;
@@ -49,6 +50,7 @@ public class JourneyContext implements IJourneyContext
 	private IJourneyBreadcrumb breadcrumb;
 	private final Map<String, Object> inputs = new ConcurrentHashMap<>(2);
 	private final List<IJourneyObserver> journeyObservers = new CopyOnWriteArrayList<>();
+	private final List<IJourneyPassenger> journeyPassengers = new CopyOnWriteArrayList<>();
 	private final IJourneyBrowserArguments browserArguments = new DefaultJourneyBrowserArguments();
 	
 	void setBrowser(IBrowser browser)
@@ -84,6 +86,18 @@ public class JourneyContext implements IJourneyContext
 	public void setJourneyObservers(List<IJourneyObserver> observers)
 	{
 		this.journeyObservers.addAll(observers);
+	}
+
+	@Override
+	public List<IJourneyPassenger> getJourneyPassengers()
+	{
+		return Collections.unmodifiableList(this.journeyPassengers);
+	}
+
+	@Override
+	public void setJourneyPassengers(List<IJourneyPassenger> passengers)
+	{
+		this.journeyPassengers.addAll(passengers);
 	}
 
 	@Override

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/TravelOptions.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/TravelOptions.java
@@ -26,6 +26,7 @@ package io.github.jamoamo.webjourney;
 import io.github.jamoamo.webjourney.api.IJourneyObserver;
 import io.github.jamoamo.webjourney.api.ITravelOptions;
 import io.github.jamoamo.webjourney.api.IRetryPolicy;
+import io.github.jamoamo.webjourney.api.IJourneyPassenger;
 import io.github.jamoamo.webjourney.api.web.IPreferredBrowserStrategy;
 import io.github.jamoamo.webjourney.api.web.PreferredBrowserStrategy;
 import io.github.jamoamo.webjourney.reserved.selenium.ChromeBrowserFactory;
@@ -43,6 +44,8 @@ public final class TravelOptions implements ITravelOptions
 			  = new PreferredBrowserStrategy(new ChromeBrowserFactory());
 	
 	private List<IJourneyObserver> journeyObservers = new ArrayList<>();
+
+	private List<IJourneyPassenger> journeyPassengers = new ArrayList<>();
 
 	private IRetryPolicy retryPolicy = io.github.jamoamo.webjourney.api.RetryPolicyBuilder.builder().build();
 
@@ -87,6 +90,26 @@ public final class TravelOptions implements ITravelOptions
 		return Collections.unmodifiableList(this.journeyObservers);
 	}
 	
+	/**
+	 * Adds a passenger to the journey.
+	 * @param passenger the passenger to add.
+	 */
+	@Override
+	public void addPassenger(IJourneyPassenger passenger)
+	{
+		this.journeyPassengers.add(passenger);
+	}
+
+	/**
+	 * Retrieves the journey passengers.
+	 * @return the journey passengers
+	 */
+	@Override
+	public List<IJourneyPassenger> getJourneyPassengers()
+	{
+		return Collections.unmodifiableList(this.journeyPassengers);
+	}
+
 	@Override
 	public IRetryPolicy getRetryPolicy()
 	{

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/WebTraveller.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/WebTraveller.java
@@ -73,6 +73,7 @@ public class WebTraveller
 		IJourneyBreadcrumb breadcrumb = new JourneyBreadcrumb();
 		context.setJourneyBreadcrumb(breadcrumb);
 		context.setJourneyObservers(this.travelOptions.getJourneyObservers());
+		context.setJourneyPassengers(this.travelOptions.getJourneyPassengers());
 		
 		// Create browser with context for browser arguments
 		IBrowser browser = browserStrategy.getPreferredBrowser(new DefaultBrowserOptions(), context);

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyContext.java
@@ -70,6 +70,18 @@ public interface IJourneyContext
 	void setJourneyObservers(List<IJourneyObserver> observers);
 	
 	/**
+	 * Gets all the passengers of the journey.
+	 * @return the journey passengers.
+	 */
+	List<IJourneyPassenger> getJourneyPassengers();
+
+	/**
+	 * Sets all the passengers of the journey.
+	 * @param passengers The journey passengers
+	 */
+	void setJourneyPassengers(List<IJourneyPassenger> passengers);
+
+	/**
 	 * Gets the breadcrumb of the current journey.
 	 * @return the breadcrumb.
 	 */

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyPassenger.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/IJourneyPassenger.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
-import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
+import io.github.jamoamo.webjourney.api.event.EntityScrapeCompletedEvent;
+import io.github.jamoamo.webjourney.api.event.EntityScrapeStartedEvent;
+import io.github.jamoamo.webjourney.api.event.IJourneyEvent;
 
 /**
+ * A passenger on a journey that is notified of journey events.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public interface IJourneyPassenger
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
-	{
-		this.target = target;
-	}
+	/**
+	 * Called when a new entity scrape has started.
+	 *
+	 * @param event the event
+	 */
+	void entityScrapeStarted(EntityScrapeStartedEvent event);
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
-	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
+	/**
+	 * Called when an entity scrape has completed.
+	 *
+	 * @param event the event
+	 */
+	void entityScrapeCompleted(EntityScrapeCompletedEvent event);
 
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
-	}
+	/**
+	 * Called when any other event occurs.
+	 *
+	 * @param event the event
+	 */
+	void onEvent(IJourneyEvent event);
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ITravelOptions.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/ITravelOptions.java
@@ -55,6 +55,18 @@ public interface ITravelOptions
 	 * @return the journey observers
 	 */
 	List<IJourneyObserver> getJourneyObservers();
+
+	/**
+	 * Adds a passenger to the journey.
+	 * @param passenger the passenger to add.
+	 */
+	void addPassenger(IJourneyPassenger passenger);
+
+	/**
+	 * Retrieves the journey passengers.
+	 * @return the journey passengers
+	 */
+	List<IJourneyPassenger> getJourneyPassengers();
 	
 	/**
 	 * Retrieves the retry policy for operations that can be retried.

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/AWebJourneyEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/AWebJourneyEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
+import java.time.LocalDateTime;
 
 /**
+ * Base class for journey events.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public abstract class AWebJourneyEvent implements IJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
+	private final LocalDateTime timestamp;
+	private final IJourneyContext context;
+
+	protected AWebJourneyEvent(IJourneyContext context)
 	{
-		this.target = target;
+		this.timestamp = LocalDateTime.now();
+		this.context = context;
 	}
 
 	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
+	public LocalDateTime getTimestamp()
 	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
+		return this.timestamp;
 	}
 
 	@Override
-	protected String getActionName()
+	public IJourneyContext getContext()
 	{
-		return "Navigate";
+		return this.context;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/EntityScrapeCompletedEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/EntityScrapeCompletedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
 
 /**
+ * Event fired when an entity scrape is completed.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public class EntityScrapeCompletedEvent extends AWebJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
+	private final Object entity;
+
+	public EntityScrapeCompletedEvent(IJourneyContext context, Object entity)
 	{
-		this.target = target;
+		super(context);
+		this.entity = entity;
 	}
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
+	public Object getEntity()
 	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
+		return this.entity;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/EntityScrapeStartedEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/EntityScrapeStartedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
 
 /**
+ * Event fired when an entity scrape starts.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public class EntityScrapeStartedEvent extends AWebJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
+	private final Class<?> entityClass;
+
+	public EntityScrapeStartedEvent(IJourneyContext context, Class<?> entityClass)
 	{
-		this.target = target;
+		super(context);
+		this.entityClass = entityClass;
 	}
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
+	public Class<?> getEntityClass()
 	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
+		return this.entityClass;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/FormCompletedEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/FormCompletedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
 
 /**
+ * Event fired when a form is completed.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public class FormCompletedEvent extends AWebJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
+	private final Object form;
+
+	public FormCompletedEvent(IJourneyContext context, Object form)
 	{
-		this.target = target;
+		super(context);
+		this.form = form;
 	}
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
+	public Object getForm()
 	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
+		return this.form;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/IJourneyEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/IJourneyEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
+import java.time.LocalDateTime;
 
 /**
+ * An event that occurs during a journey.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public interface IJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
-	{
-		this.target = target;
-	}
+	/**
+	 * @return The timestamp when the event occurred.
+	 */
+	LocalDateTime getTimestamp();
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
-	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
-	}
+	/**
+	 * @return The context of the journey when the event occurred.
+	 */
+	IJourneyContext getContext();
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/PageNavigatedEvent.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/api/event/PageNavigatedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2023 James Amoore.
+ * Copyright 2024 James Amoore.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,41 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.github.jamoamo.webjourney;
+package io.github.jamoamo.webjourney.api.event;
 
-import io.github.jamoamo.webjourney.api.AWebAction;
 import io.github.jamoamo.webjourney.api.IJourneyContext;
-import io.github.jamoamo.webjourney.api.event.PageNavigatedEvent;
-import io.github.jamoamo.webjourney.api.web.IBrowser;
 
 /**
+ * Event fired when a page navigation is completed.
  *
  * @author James Amoore
  */
-class NavigateAction extends AWebAction
+public class PageNavigatedEvent extends AWebJourneyEvent
 {
-	private final ANavigationTarget target;
-	
-	NavigateAction(ANavigationTarget target)
+	private final String url;
+
+	public PageNavigatedEvent(IJourneyContext context, String url)
 	{
-		this.target = target;
+		super(context);
+		this.url = url;
 	}
 
-	@Override
-	protected ActionResult executeActionImpl(IJourneyContext context)
+	public String getUrl()
 	{
-		IBrowser browser = context.getBrowser();
-		this.target.navigate(browser);
-
-		PageNavigatedEvent event = new PageNavigatedEvent(context, browser.getActiveWindow().getCurrentUrl());
-		context.getJourneyPassengers().forEach(p -> p.onEvent(event));
-
-		return ActionResult.SUCCESS;
-	}
-
-	@Override
-	protected String getActionName()
-	{
-		return "Navigate";
+		return this.url;
 	}
 }

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/entity/EntityCreationContext.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/entity/EntityCreationContext.java
@@ -65,6 +65,8 @@ public final class EntityCreationContext
 
 	 private IRetryPolicy retryPolicy;
 
+	 private io.github.jamoamo.webjourney.api.IJourneyContext journeyContext;
+
 	 EntityCreationContext(EntityDefn entityDefn)
 	 {
 		  this.baseEntity = entityDefn;
@@ -78,6 +80,23 @@ public final class EntityCreationContext
 		  this.retryPolicy = retryPolicy;
 	 }
 	 
+	 public EntityCreationContext(EntityDefn entityDefn, IRetryPolicy retryPolicy,
+		io.github.jamoamo.webjourney.api.IJourneyContext journeyContext)
+	 {
+		  this(entityDefn, retryPolicy);
+		  this.journeyContext = journeyContext;
+	 }
+
+	 /**
+	  * Gets the journey context.
+	  *
+	  * @return the journey context
+	  */
+	 public io.github.jamoamo.webjourney.api.IJourneyContext getJourneyContext()
+	 {
+		  return this.journeyContext;
+	 }
+
 	 /**
 	  * Gets the retry policy configured for this context.
 	  * 

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/entity/EntityCreator.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/reserved/entity/EntityCreator.java
@@ -24,6 +24,8 @@
 package io.github.jamoamo.webjourney.reserved.entity;
 
 import io.github.jamoamo.webjourney.api.entity.IEntityCreationListener;
+import io.github.jamoamo.webjourney.api.event.EntityScrapeCompletedEvent;
+import io.github.jamoamo.webjourney.api.event.EntityScrapeStartedEvent;
 import io.github.jamoamo.webjourney.api.web.AElement;
 import io.github.jamoamo.webjourney.api.web.IBrowser;
 import java.lang.reflect.InvocationTargetException;
@@ -279,6 +281,16 @@ public final class EntityCreator<T>
 
 	private void fireEntityCreated(T instance)
 	{
+		if (this.context != null && this.context.getJourneyContext() != null)
+		{
+			EntityScrapeCompletedEvent event = new EntityScrapeCompletedEvent(this.context.getJourneyContext(), instance);
+			this.context.getJourneyContext().getJourneyPassengers().forEach(p ->
+			{
+				p.entityScrapeCompleted(event);
+				p.onEvent(event);
+			});
+		}
+
 		if (this.creationListeners == null)
 		{
 			return;
@@ -288,6 +300,17 @@ public final class EntityCreator<T>
 
 	private void fireEntityCreationStarted()
 	{
+		if (this.context != null && this.context.getJourneyContext() != null)
+		{
+			EntityScrapeStartedEvent event =
+				new EntityScrapeStartedEvent(this.context.getJourneyContext(), this.defn.getFieldType());
+			this.context.getJourneyContext().getJourneyPassengers().forEach(p ->
+			{
+				p.entityScrapeStarted(event);
+				p.onEvent(event);
+			});
+		}
+
 		if (this.creationListeners == null)
 		{
 			return;

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/api/web/DefaultBrowserArgumentsProviderTest.java
@@ -159,6 +159,17 @@ class DefaultBrowserArgumentsProviderTest
         }
 
         @Override
+        public List<io.github.jamoamo.webjourney.api.IJourneyPassenger> getJourneyPassengers()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void setJourneyPassengers(List<io.github.jamoamo.webjourney.api.IJourneyPassenger> passengers)
+        {
+        }
+
+        @Override
         public IJourneyBreadcrumb getJourneyBreadcrumb()
         {
             return null;


### PR DESCRIPTION
This commit introduces a new way to listen to specific occurrences during a web journey. The new `IJourneyPassenger` allows receiving specific typed events such as `PageNavigatedEvent` and `FormCompletedEvent`, as well as listening to entity scraping progress. Users can register their passengers onto `TravelOptions`, which makes them available throughout the journey context.

Fixes an issue where it was difficult to extract information about when an entity scrape began or finished, or when form submissions and navigations occurred.

---
*PR created automatically by Jules for task [8093779597912065667](https://jules.google.com/task/8093779597912065667) started by @jamoamo*