### PR TITLE
Add waitUntilUrlChangesFrom journey step

### DIFF
--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/BaseJourneyBuilder.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/BaseJourneyBuilder.java
@@ -30,6 +30,7 @@ import io.github.jamoamo.webjourney.api.JourneyBuilderException;
 import io.github.jamoamo.webjourney.api.web.IBrowser;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.function.Function;
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableFunction;
@@ -41,6 +42,8 @@ import org.apache.commons.lang3.function.FailableFunction;
  */
 public class BaseJourneyBuilder implements IJourneyBuilder
 {
+	private static final int DEFAULT_URL_CHANGE_TIMEOUT_SEC = 10;
+
 	private final JourneyBuild build;
 
 	BaseJourneyBuilder()
@@ -182,6 +185,35 @@ public class BaseJourneyBuilder implements IJourneyBuilder
 	{
 		ConsumePageAction<T> action = new ConsumePageAction<>(pageClass, pageConsumer);
 		this.build.addAction(action);
+		return new ActionOptionsJourneyBuilder(this.build);
+	}
+
+	/**
+	 * Adds an action that waits until the active window's url no longer contains the provided substring. A default
+	 * timeout of 10 seconds is applied. This is useful when a previous action lands on an intermediate url that
+	 * redirects to the desired page.
+	 *
+	 * @param urlSubstring The url substring to wait away from.
+	 *
+	 * @return the current builder
+	 */
+	public ActionOptionsJourneyBuilder waitUntilUrlChangesFrom(String urlSubstring)
+	{
+		return waitUntilUrlChangesFrom(urlSubstring, Duration.ofSeconds(DEFAULT_URL_CHANGE_TIMEOUT_SEC));
+	}
+
+	/**
+	 * Adds an action that waits until the active window's url no longer contains the provided substring. This is useful
+	 * when a previous action lands on an intermediate url that redirects to the desired page.
+	 *
+	 * @param urlSubstring The url substring to wait away from.
+	 * @param timeout      The maximum time to wait before failing.
+	 *
+	 * @return the current builder
+	 */
+	public ActionOptionsJourneyBuilder waitUntilUrlChangesFrom(String urlSubstring, Duration timeout)
+	{
+		this.build.addAction(new WaitUntilUrlChangesAction(urlSubstring, timeout));
 		return new ActionOptionsJourneyBuilder(this.build);
 	}
 

--- a/webjourney/src/main/java/io/github/jamoamo/webjourney/WaitUntilUrlChangesAction.java
+++ b/webjourney/src/main/java/io/github/jamoamo/webjourney/WaitUntilUrlChangesAction.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney;
+
+import io.github.jamoamo.webjourney.api.AWebAction;
+import io.github.jamoamo.webjourney.api.IJourneyContext;
+import io.github.jamoamo.webjourney.api.web.IBrowser;
+import java.time.Duration;
+
+/**
+ * Action that blocks until the active window's url no longer contains a given substring. This is useful when a previous
+ * action lands on an intermediate url that redirects to the desired page; waiting for the url to change away from the
+ * intermediate url avoids acting on the wrong page.
+ *
+ * @author James Amoore
+ */
+class WaitUntilUrlChangesAction extends AWebAction
+{
+	private static final long POLL_INTERVAL_MILLIS = 250;
+
+	private final String urlSubstring;
+	private final Duration timeout;
+
+	WaitUntilUrlChangesAction(String urlSubstring, Duration timeout)
+	{
+		if(urlSubstring == null)
+		{
+			throw new NullPointerException("Url substring should not be null.");
+		}
+
+		if(timeout == null)
+		{
+			throw new NullPointerException("Timeout should not be null.");
+		}
+
+		this.urlSubstring = urlSubstring;
+		this.timeout = timeout;
+	}
+
+	@Override
+	protected ActionResult executeActionImpl(IJourneyContext context)
+			  throws BaseJourneyActionException
+	{
+		try
+		{
+			IBrowser browser = context.getBrowser();
+			long deadline = System.currentTimeMillis() + this.timeout.toMillis();
+
+			while(browser.getActiveWindow().getCurrentUrl().contains(this.urlSubstring))
+			{
+				if(System.currentTimeMillis() >= deadline)
+				{
+					throw new BaseJourneyActionException(
+							  "Timed out after " + this.timeout.toMillis()
+							  + "ms waiting for the url to change away from [" + this.urlSubstring + "].",
+							  this, null);
+				}
+
+				Thread.sleep(POLL_INTERVAL_MILLIS);
+			}
+		}
+		catch(InterruptedException ex)
+		{
+			Thread.currentThread().interrupt();
+			throw new BaseJourneyActionException(ex.getMessage(), this, ex);
+		}
+		catch(BaseJourneyActionException ex)
+		{
+			throw ex;
+		}
+		catch(Exception ex)
+		{
+			throw new BaseJourneyActionException(ex.getMessage(), this, ex);
+		}
+
+		return ActionResult.SUCCESS;
+	}
+
+	@Override
+	protected String getActionName()
+	{
+		return "Wait Until Url Changes";
+	}
+}

--- a/webjourney/src/test/java/io/github/jamoamo/webjourney/WaitUntilUrlChangesActionTest.java
+++ b/webjourney/src/test/java/io/github/jamoamo/webjourney/WaitUntilUrlChangesActionTest.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 James Amoore.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.github.jamoamo.webjourney;
+
+import io.github.jamoamo.webjourney.api.web.IBrowser;
+import io.github.jamoamo.webjourney.api.web.IBrowserWindow;
+import io.github.jamoamo.webjourney.api.web.XWebException;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.Mockito;
+
+/**
+ *
+ * @author James Amoore
+ */
+public class WaitUntilUrlChangesActionTest
+{
+
+	 public WaitUntilUrlChangesActionTest()
+	 {
+	 }
+
+	 /**
+	  * Test of executeAction method when the url has already changed away from the substring.
+	  */
+	 @Test
+	 public void testExecuteAction_urlAlreadyChanged()
+		  throws Exception
+	 {
+		  IBrowser browser = Mockito.mock(IBrowser.class);
+		  IBrowserWindow window = Mockito.mock(IBrowserWindow.class);
+		  Mockito.when(browser.getActiveWindow())
+				.thenReturn(window);
+		  Mockito.when(window.getCurrentUrl())
+				.thenReturn("https://example.com/match.cgi");
+		  JourneyContext context = new JourneyContext();
+		  context.setBrowser(browser);
+
+		  WaitUntilUrlChangesAction action =
+				new WaitUntilUrlChangesAction("intermediate.cgi", Duration.ofSeconds(1));
+		  ActionResult result = action.executeAction(context);
+		  assertEquals(ActionResult.SUCCESS, result);
+	 }
+
+	 /**
+	  * Test of executeAction method when the url changes away from the substring after polling.
+	  */
+	 @Test
+	 public void testExecuteAction_urlChangesAfterPolling()
+		  throws Exception
+	 {
+		  IBrowser browser = Mockito.mock(IBrowser.class);
+		  IBrowserWindow window = Mockito.mock(IBrowserWindow.class);
+		  Mockito.when(browser.getActiveWindow())
+				.thenReturn(window);
+		  Mockito.when(window.getCurrentUrl())
+				.thenReturn("https://example.com/intermediate.cgi")
+				.thenReturn("https://example.com/intermediate.cgi")
+				.thenReturn("https://example.com/match.cgi");
+		  JourneyContext context = new JourneyContext();
+		  context.setBrowser(browser);
+
+		  WaitUntilUrlChangesAction action =
+				new WaitUntilUrlChangesAction("intermediate.cgi", Duration.ofSeconds(5));
+		  ActionResult result = action.executeAction(context);
+		  assertEquals(ActionResult.SUCCESS, result);
+
+		  Mockito.verify(window, Mockito.times(3))
+				.getCurrentUrl();
+	 }
+
+	 /**
+	  * Test of executeAction method when the url never changes and the timeout is exceeded.
+	  */
+	 @Test
+	 public void testExecuteAction_timeout()
+		  throws Exception
+	 {
+		  IBrowser browser = Mockito.mock(IBrowser.class);
+		  IBrowserWindow window = Mockito.mock(IBrowserWindow.class);
+		  Mockito.when(browser.getActiveWindow())
+				.thenReturn(window);
+		  Mockito.when(window.getCurrentUrl())
+				.thenReturn("https://example.com/intermediate.cgi");
+		  JourneyContext context = new JourneyContext();
+		  context.setBrowser(browser);
+
+		  WaitUntilUrlChangesAction action =
+				new WaitUntilUrlChangesAction("intermediate.cgi", Duration.ofMillis(300));
+		  assertThrows(BaseJourneyActionException.class, () -> action.executeAction(context));
+	 }
+
+	 /**
+	  * Test of executeAction method when retrieving the url throws a browsing error.
+	  */
+	 @Test
+	 public void testExecuteAction_urlError()
+		  throws Exception
+	 {
+		  IBrowser browser = Mockito.mock(IBrowser.class);
+		  IBrowserWindow window = Mockito.mock(IBrowserWindow.class);
+		  Mockito.when(browser.getActiveWindow())
+				.thenReturn(window);
+		  Mockito.when(window.getCurrentUrl())
+				.thenThrow(new XWebException("Browsing error"));
+		  JourneyContext context = new JourneyContext();
+		  context.setBrowser(browser);
+
+		  WaitUntilUrlChangesAction action =
+				new WaitUntilUrlChangesAction("intermediate.cgi", Duration.ofSeconds(1));
+		  assertThrows(BaseJourneyActionException.class, () -> action.executeAction(context));
+	 }
+
+}


### PR DESCRIPTION
Adds WaitUntilUrlChangesAction, which polls the active window's URL every 250ms until it no longer contains a given substring, throwing BaseJourneyActionException on timeout. Exposed via two new BaseJourneyBuilder.waitUntilUrlChangesFrom overloads (default 10s timeout and an explicit Duration), so a journey can block on an intermediate redirect URL before consuming the destination page.